### PR TITLE
Update Head Names

### DIFF
--- a/src/main/java/com/rokucraft/rokuwear/util/Heads.java
+++ b/src/main/java/com/rokucraft/rokuwear/util/Heads.java
@@ -14,13 +14,13 @@ import java.util.UUID;
 
 public class Heads {
     public static final ItemStack NEXT_ARROW_HEAD = getHead(
-            Component.text("Next page", NamedTextColor.YELLOW),
+            Component.text("Next", NamedTextColor.YELLOW),
             "Oak Wood Arrow Right",
             "d513d666-0992-42c7-9aa6-e518a83e0b38",
             "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTliZjMyOTJlMTI2YTEwNWI1NGViYTcxM2FhMWIxNTJkNTQxYTFkODkzODgyOWM1NjM2NGQxNzhlZDIyYmYifX19");
 
     public static final ItemStack PREVIOUS_ARROW_HEAD = getHead(
-            Component.text("Previous page", NamedTextColor.YELLOW),
+            Component.text("Previous", NamedTextColor.YELLOW),
             "Oak Wood Arrow Left",
             "2391d533-ab09-434d-9980-adafde4057a3",
             "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmQ2OWUwNmU1ZGFkZmQ4NGU1ZjNkMWMyMTA2M2YyNTUzYjJmYTk0NWVlMWQ0ZDcxNTJmZGM1NDI1YmMxMmE5In19fQ==");


### PR DESCRIPTION
This aligns with RokuShop's naming system, removing the unnecessary 'page' bit.

Could maybe change `Previous` to `Back` though, thoughts? 